### PR TITLE
Resize contact us button in navbar

### DIFF
--- a/css/eliazernahorpratama.webflow.css
+++ b/css/eliazernahorpratama.webflow.css
@@ -356,7 +356,8 @@ figcaption {
 .button.cc-contact-us {
   position: relative;
   z-index: 5;
-  padding: 15px 20px;
+  padding: 8px 16px;
+  font-size: 12px;
 }
 
 .button.cc-white-button {


### PR DESCRIPTION
Reduce the size of the 'Contact Us' button in the navigation bar for better proportionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-f640a53f-1932-4531-b1c0-042689762073">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f640a53f-1932-4531-b1c0-042689762073">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

