### PR TITLE
Resize project cards for three per row

### DIFF
--- a/index.html
+++ b/index.html
@@ -500,8 +500,8 @@
     
     .grid-content {
       display: grid !important;
-      grid-template-columns: repeat(auto-fit, minmax(350px, 1fr)) !important;
-      gap: 30px !important;
+      grid-template-columns: repeat(3, 1fr) !important;
+      gap: 20px !important;
       margin-bottom: 50px !important;
     }
     
@@ -521,7 +521,7 @@
     
     .picture-section {
       width: 100% !important;
-      height: 250px !important;
+      height: 200px !important;
       overflow: hidden !important;
     }
     
@@ -537,15 +537,15 @@
     }
     
     .text-section {
-      padding: 20px !important;
+      padding: 15px !important;
       text-align: center !important;
     }
     
     .heading-2 {
-      font-size: 24px !important;
+      font-size: 20px !important;
       font-weight: 700 !important;
       color: #2c3e50 !important;
-      margin-bottom: 15px !important;
+      margin-bottom: 10px !important;
       letter-spacing: 0.5px !important;
       text-transform: none !important;
     }
@@ -583,6 +583,13 @@
     }
     
     /* Responsive Design */
+    @media (max-width: 1024px) {
+      .grid-content {
+        grid-template-columns: repeat(2, 1fr) !important;
+        gap: 20px !important;
+      }
+    }
+    
     @media (max-width: 768px) {
       .projects-main-title {
         font-size: 36px !important;


### PR DESCRIPTION
Adjust card sizing and grid layout in the PROJECTS SECTION to display 3 cards per row on desktop.

The previous grid configuration for the `.grid-content` class used `minmax(350px, 1fr)`, which often resulted in fewer than 3 cards per row on standard desktop screens. This PR explicitly sets the grid to 3 columns and reduces card element dimensions to ensure a compact, consistent 3-card layout, along with improved responsiveness for smaller screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-45c3dd21-1666-4f0a-80d2-513e3de8aa7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-45c3dd21-1666-4f0a-80d2-513e3de8aa7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

