### PR TITLE
Go to contact menu

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -185,12 +185,32 @@
     /* Location Section Background */
     .location-container {
       background-color: #ffffff !important;
+      background-image: none !important;
       padding: 40px 20px;
     }
     
     /* Override intro-section gradient for location section */
     .intro-section.location-section-wrapper {
       background-color: #ffffff !important;
+      background-image: none !important;
+    }
+    
+    /* Ensure location section has pure white background */
+    .location-section {
+      background-color: #ffffff !important;
+      background-image: none !important;
+    }
+    
+    /* Ensure section-block has white background */
+    .section-block {
+      background-color: #ffffff !important;
+      background-image: none !important;
+    }
+    
+    /* Ensure section-block-head has white background */
+    .section-block-head {
+      background-color: #ffffff !important;
+      background-image: none !important;
     }
     
     /* Location Section Title Color */
@@ -205,19 +225,22 @@
       border-radius: 8px;
       padding: 20px;
       margin: 10px;
-      background-color: #ffffff;
+      background-color: #ffffff !important;
+      background-image: none !important;
       border: 2px solid #e0e0e0;
       box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
     }
     
     .clickable-location:hover {
-      background-color: #ffffff;
+      background-color: #ffffff !important;
+      background-image: none !important;
       transform: translateY(-2px);
       box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     }
     
     .clickable-location.active-location {
-      background-color: #ffffff;
+      background-color: #ffffff !important;
+      background-image: none !important;
       border: 2px solid #2c3e50;
       box-shadow: 0 4px 12px rgba(44, 62, 80, 0.2);
     }


### PR DESCRIPTION
Force Location Section background to white to override global body gradient.

The Location Section was inheriting a subtle grey gradient from the `body` element's global styling. This PR explicitly sets the background of the section and its interactive cards to pure white, removing the unintended grey appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-75995a94-b77b-4694-ab95-a725aecf6a43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-75995a94-b77b-4694-ab95-a725aecf6a43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

